### PR TITLE
feat: more `Book` schema properties

### DIFF
--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -100,7 +100,7 @@ export const Book = z.object({
    * Redirects are handled automatically in `book.get`.
    */
   location: z.string().optional(),
-  contributions: z.array(z.string()),
+  contributions: z.array(z.string()).optional(),
   /**
    * Array of colon-separated source identifiers
    * 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -43,7 +43,12 @@ const AuthorObj = z
       .object({
         key: z.string(),
       })
-      .transform((author) => ({ author })),
+      .transform((author) => ({
+        author,
+        type: {
+          key: "/type/author_role",
+        },
+      })),
   );
 
 const Date = z.object({

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -43,28 +43,68 @@ const Date = z.object({
   value: z.string(),
 });
 
-export const Book = z.object({
-  title: z.string().optional(),
-  key,
-  authors: z.array(AuthorObj).optional(),
-  type: z.object({
-    key: z.enum(['/type/work', '/type/redirect']),
-  }),
-  description: z.string().or(z.object({
-    type: z.literal('/type/text'),
-    value: z.string(),
-  })).transform((desc) => {
+const StringOrTextObject = z
+  .string()
+  .or(
+    z.object({
+      type: z.literal('/type/text'),
+      value: z.string(),
+    })
+  )
+  .transform((desc) => {
     if (typeof desc === 'string') {
       return desc;
     }
     return desc.value;
-  }).optional(),
+  })
+
+export const Book = z.object({
+  /**
+   * Arrays of external platform identifiers
+   * 
+   * @example { goodreads: ["1507552"], librarything: ["6446"] }
+  */
+  identifiers: z
+    .record(
+      z.string(),
+      z.array(z.string()),
+    )
+    .optional(),
+  title: z.string().optional(),
+  key,
+  authors: z.array(AuthorObj).optional(),
+  type: z.object({
+    key: z.enum(['/type/work', '/type/redirect', '/type/edition']),
+  }),
+  description: StringOrTextObject.optional(),
   covers: z.array(z.number()).optional().default([]),
   subject_places: z.array(z.string()).optional().default([]),
   subjects: z.array(z.string()).optional().default([]),
   subject_people: z.array(z.string()).optional().default([]),
   subject_times: z.array(z.string()).optional().default([]),
+  /**
+   * Redirect path for when `type.key` is `/type/redirect`.
+   * Redirects are handled automatically in `book.get`.
+   */
   location: z.string().optional(),
+  contributions: z.array(z.string()),
+  /**
+   * Array of colon-separated source identifiers
+   * 
+   * @example `ia:fantasticmrfox00dahl_834` = `archive.org/details/fantasticmrfox00dahl_834`
+   */
+  source_records: z.array(z.string()).optional().default([]),
+  local_id: z.array(z.string()).optional().default([]),
+  // Not confident that this could be a string but I saw that `description`
+  // unioned a /type/text object so I thought it would make sense for them
+  // to be the same.
+  first_sentence: StringOrTextObject.optional(),
+  number_of_pages: z.number().optional(),
+  works: z.array(z.object({ key })),
+  /** Internet archive ID */
+  ocaid: z.string().optional(),
+  isbn_10: z.array(z.string()).optional(),
+  isbn_13: z.array(z.string()).optional(),
   latest_revision: z.number(),
   revision: z.number(),
   created: Date,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -29,14 +29,22 @@ export const Search = z.object({
   docs: z.array(Doc).default([]),
 });
 
-const AuthorObj = z.object({
-  author: z.object({
-    key: z.string(),
-  }),
-  type: z.object({
-    key: z.string(),
-  }),
-});
+const AuthorObj = z
+  .object({
+    author: z.object({
+      key: z.string(),
+    }),
+    type: z.object({
+      key: z.string(),
+    }),
+  })
+  .or(
+    z
+      .object({
+        key: z.string(),
+      })
+      .transform((author) => ({ author })),
+  );
 
 const Date = z.object({
   type: z.literal('/type/datetime'),

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -113,7 +113,7 @@ export const Book = z.object({
   // to be the same.
   first_sentence: StringOrTextObject.optional(),
   number_of_pages: z.number().optional(),
-  works: z.array(z.object({ key })),
+  works: z.array(z.object({ key })).optional(),
   /** Internet archive ID */
   ocaid: z.string().optional(),
   isbn_10: z.array(z.string()).optional(),


### PR DESCRIPTION
This PR just adds a few optional properties missing from `Book`. Examples of each can be found here: https://openlibrary.org/books/OL7353617M.json (in this case, `/books/:id` was redirected from `/works/:id`, so the same should apply to responses from `getRequest`).

I also modified `AuthorObj` to accept a value of just `{ key: "/authors/..." }`, which is also found in the above example. This would be a breaking change but I decided to transform the value to be compatible with the prior schema so it should be fine for applications that depend on that.

Some other observations I had, but did not address, include:
- The `Date` schema shadows javascript's `Date`, which my linter is not fond of.
- `getByISBN`'s omission of a leading slash when assigning `pathname` (I guess this works fine, but it seems weird)
- Every query function assigns values to the same `API_URL`, which seems like it could cause problems since there would be residue for instances like `book.search`, which assigns a query parameter, but no other functions overwrite it. I think it would be better practice to create a new URL within each function like so: `new URL('/works/...', API_URL)`
- `mod.ts` does not export any schemas or types, which makes it challenging to refer to types from this package or extend schemas
- The schemas are not utilizing Zod's [passthrough](https://zod.dev/?id=passthrough), which of course means unknown keys like the ones I added are completely inaccessible to the user. Personally I think users should have some way to access this data even if it's untyped (for example, while waiting for PR approval lol).